### PR TITLE
カンマ区切りでAddHeaderオプションを複数指定可能に

### DIFF
--- a/ab-mruby.c
+++ b/ab-mruby.c
@@ -2531,13 +2531,19 @@ int main(int argc, const char * const argv[])
         char *addhdr = NULL;
         mrb_get_config_value(mrb, "AddHeader",  "z", &addhdr);
         if (addhdr != NULL) {
-            hdrs = apr_pstrcat(cntxt, hdrs, addhdr, "\r\n", NULL);
-            if (strncasecmp(addhdr, "Host:", 5) == 0) {
-                opt_host = 1;
-            } else if (strncasecmp(addhdr, "Accept:", 7) == 0) {
-                opt_accept = 1;
-            } else if (strncasecmp(addhdr, "User-Agent:", 11) == 0) {
-                opt_useragent = 1;
+            char *tok;
+            char separator_str[] = ",";
+            tok = strtok(addhdr,separator_str);
+            while (tok != NULL) {
+                hdrs = apr_pstrcat(cntxt, hdrs, tok, "\r\n", NULL);
+                if (strncasecmp(tok, "Host:", 5) == 0) {
+                    opt_host = 1;
+                } else if (strncasecmp(tok, "Accept:", 7) == 0) {
+                    opt_accept = 1;
+                } else if (strncasecmp(tok, "User-Agent:", 11) == 0) {
+                    opt_useragent = 1;
+                }
+                tok = strtok(NULL, separator_str);
             }
         }
 


### PR DESCRIPTION
`ab` コマンドで可能なHeaderを複数指定することができなかったため、カンマ区切りで複数指定可能にしました。

例) UserAgent と Hostを指定したい

- 以下の通り `Host: hogefuga.tap1ra.jp` と `User-Agent: HogeFugaUA` を指定
  `"AddHeader"             => 'Host: hogefuga.tap1ra.jp,User-Agent: HogeFugaUA',`
- `-H` でHeader指定をせずab-mrubyを実行
  `./ab-mruby -m ab-mruby.conf.rb -M ab-mruby.test.rb http://127.0.0.1/wp/`
- アクセスログからHostとUserAgentが渡っていることを確認
  `hogefuga.tap1ra.jp 127.0.0.1 - - [20/Dec/2016:00:41:04 +0900] "GET /wp/ HTTP/1.0" 404 8262 "-" "HogeFugaUA"`
